### PR TITLE
chore: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ go test -v --cover --race ./...
 
 ### MySQL
 
-#### Show database table sizes in MB and fragmented space in MB
+#### Show database table sizes in GB and fragmented space in GB
 
 ```sql
 SELECT


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Documentation: README.mdのMySQLセクションで、データベーステーブルサイズと断片化スペースの表示単位がMBからGBに更新されました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->