### PR TITLE
fix: refactor logging setup

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,10 @@ var (
 
 func setupLogging(ctx context.Context) {
 	logLevel := new(slog.LevelVar)
+	logLevel.Set(slog.LevelError)
+	if *debug {
+		logLevel.Set(slog.LevelDebug)
+	}
 	opts := &slog.HandlerOptions{
 		AddSource: *debug,
 		Level:     logLevel,
@@ -44,10 +48,6 @@ func setupLogging(ctx context.Context) {
 	)
 
 	slog.SetDefault(logger)
-
-	if *debug {
-		logLevel.Set(slog.LevelDebug)
-	}
 }
 
 func main() {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `main.go`に`setupLogging`関数が追加されました。これにより、ログ設定のリファクタリングが行われ、デバッグモードが有効な場合にはログレベルがデバッグに設定されるようになりました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->