### PR TITLE
fix: custom ldfags not change version

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,11 +14,8 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 )
 
-const (
-	version = "0.0.0"
-)
-
 var (
+	version       = "0.0.0"
 	commit        = "HEAD"
 	date          = "2021-09-30T00:00:00Z"
 	builtBy       = "unknown"


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `main.go`の`version`変数が再定義されました。以前は定数として宣言されていましたが、現在は変数として扱われます。この変更はコードのロジックや機能に影響を与えません。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->