### PR TITLE
fix: refactor signal handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	slog.InfoContext(ctx, "start generating fake data")
 
-	handleSignals(ctx, cancel)
+	go handleSignals(ctx, cancel)
 
 	// Handle errors from goroutines.
 	errChan := make(chan error, 1)
@@ -143,7 +143,7 @@ func main() {
 		}
 	}()
 
-	slog.InfoContext(ctx, "fisnish generating fake data")
+	slog.InfoContext(ctx, "finish generating fake data")
 }
 
 func handleSignals(ctx context.Context, cancel context.CancelFunc) {

--- a/main.go
+++ b/main.go
@@ -43,9 +43,7 @@ func main() {
 
 	slog.InfoContext(ctx, "start generating fake data")
 
-	// Handle SIGINT and SIGTERM.
-	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	handleSignals(ctx, cancel)
 
 	// Handle errors from goroutines.
 	errChan := make(chan error, 1)
@@ -145,14 +143,17 @@ func main() {
 		}
 	}()
 
-	// Handle SIGINT and SIGTERM.
+	slog.InfoContext(ctx, "fisnish generating fake data")
+}
+
+func handleSignals(ctx context.Context, cancel context.CancelFunc) {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		<-sigs
-		slog.DebugContext(ctx, "received SIGINT or SIGTERM")
+		sig := <-sigs
+		slog.DebugContext(ctx, "received signal", "signal", sig)
 		cancel()
 		slog.InfoContext(ctx, "cancel generating fake data")
 		os.Exit(1)
 	}()
-
-	slog.InfoContext(ctx, "fisnish generating fake data")
 }

--- a/main.go
+++ b/main.go
@@ -154,5 +154,6 @@ func handleSignals(ctx context.Context, cancel context.CancelFunc) {
 		slog.DebugContext(ctx, "received signal", "signal", sig)
 		cancel()
 		slog.InfoContext(ctx, "cancel generating fake data")
+		os.Exit(1)
 	}()
 }

--- a/main.go
+++ b/main.go
@@ -154,6 +154,5 @@ func handleSignals(ctx context.Context, cancel context.CancelFunc) {
 		slog.DebugContext(ctx, "received signal", "signal", sig)
 		cancel()
 		slog.InfoContext(ctx, "cancel generating fake data")
-		os.Exit(1)
 	}()
 }


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `main.go`の`main()`関数がリファクタリングされ、シグナルハンドリングが新たに`handleSignals()`関数に分離されました。これにより、`SIGINT`と`SIGTERM`シグナルの処理が改善され、プログラムの終了ステータスがより明確になりました。

<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->