### PR TITLE
fix: refactor worker goroutine to handle multiple data types

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,6 +175,8 @@ func processBatch(ctx context.Context, db *sql.DB, items interface{}, errChan ch
 		slog.DebugContext(ctx, "Inserting PanelOrderItems", "numItems", len(v), "item", fmt.Sprintf("%T", v))
 		if err := v.BulkInsert(ctx, db); err != nil {
 			slog.ErrorContext(ctx, "Failed to bulk insert", "error", err)
+			errChan <- fmt.Errorf("failed to bulk insert: %w", err)
+			return
 		}
 	default:
 		slog.ErrorContext(ctx, "Unknown type in batch", "type", fmt.Sprintf("%T", v))

--- a/main.go
+++ b/main.go
@@ -168,9 +168,9 @@ func bulkInserter(ctx context.Context, db *sql.DB, dataChan <-chan DataItems, ba
 	}
 }
 
-func processBatch(ctx context.Context, db *sql.DB, items interface{}, errChan chan<- error) {
-	slog.DebugContext(ctx, "Processing batch", "item", fmt.Sprintf("%T", items))
-	switch v := items.(type) {
+func processBatch(ctx context.Context, db *sql.DB, di DataItem, errChan chan<- error) {
+	slog.DebugContext(ctx, "Processing batch", "item", fmt.Sprintf("%T", di))
+	switch v := di.(type) {
 	case PanelOrderItems:
 		slog.DebugContext(ctx, "Inserting PanelOrderItems", "numItems", len(v), "item", fmt.Sprintf("%T", v))
 		if err := v.BulkInsert(ctx, db); err != nil {

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func bulkInserter(ctx context.Context, db *sql.DB, dataChan <-chan DataItems, ba
 					panelOrderItemsBatch = append(panelOrderItemsBatch, v...)
 					if len(panelOrderItemsBatch) == batchSize {
 						processBatch(ctx, db, panelOrderItemsBatch, errChan)
-						panelOrderItemsBatch = make(PanelOrderItems, 0, batchSize)
+						panelOrderItemsBatch = panelOrderItemsBatch[:0]
 					}
 
 				default:

--- a/models.go
+++ b/models.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+type DataItem interface {
+	BulkInsert(ctx context.Context, db *sql.DB) error
+}
+
+type DataItems []DataItem
+
 type PanelOrderItem struct {
 	PanelOrderID int `fake:"{number:1,100}"`
 	QuestionID   int `fake:"{number:1,100}"`

--- a/models.go
+++ b/models.go
@@ -19,7 +19,7 @@ type PanelOrderItem struct {
 type PanelOrderItems []PanelOrderItem
 
 type DataItemCreator interface {
-	Create() (DataItems, error)
+	Create() (DataItems, error) // Create returns a slice of DataItem and error if the creation of DataItem fails due to any reason
 }
 
 type PanelOrderItemCreator struct{}
@@ -27,13 +27,13 @@ type PanelOrderItemCreator struct{}
 func (p *PanelOrderItemCreator) Create() (DataItems, error) {
 	var item PanelOrderItem
 	if err := gofakeit.Struct(&item); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create PanelOrderItem: %w", err)
 	}
 	return DataItems{PanelOrderItems{item}}, nil
 }
 
 type DataItem interface {
-	BulkInsert(ctx context.Context, db *sql.DB) error
+	BulkInsert(ctx context.Context, db *sql.DB) error // BulkInsert inserts the data item into the database and error if the bulk insertion of DataItems fails due to any reason
 }
 
 type DataItems []DataItem

--- a/models.go
+++ b/models.go
@@ -6,21 +6,37 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+
+	"github.com/brianvoe/gofakeit/v6"
 )
+
+type PanelOrderItem struct {
+	PanelOrderID int `fake:"{number:0,2147483647}"` // max int32
+	QuestionID   int `fake:"{number:0,2147483647}"` // max int32
+	OrderIndex   int `fake:"{number:0,2147483647}"` // max int32
+}
+
+type PanelOrderItems []PanelOrderItem
+
+type DataItemCreator interface {
+	Create() (DataItems, error)
+}
+
+type PanelOrderItemCreator struct{}
+
+func (p *PanelOrderItemCreator) Create() (DataItems, error) {
+	var item PanelOrderItem
+	if err := gofakeit.Struct(&item); err != nil {
+		return nil, err
+	}
+	return DataItems{PanelOrderItems{item}}, nil
+}
 
 type DataItem interface {
 	BulkInsert(ctx context.Context, db *sql.DB) error
 }
 
 type DataItems []DataItem
-
-type PanelOrderItem struct {
-	PanelOrderID int `fake:"{number:1,100}"`
-	QuestionID   int `fake:"{number:1,100}"`
-	OrderIndex   int `fake:"{number:1,100}"`
-}
-
-type PanelOrderItems []PanelOrderItem
 
 func (ps PanelOrderItems) BulkInsert(ctx context.Context, db *sql.DB) error {
 	// Create query for bulk insert

--- a/models.go
+++ b/models.go
@@ -11,9 +11,9 @@ import (
 )
 
 type PanelOrderItem struct {
-	PanelOrderID int `fake:"{number:0,2147483647}"` // max int32
-	QuestionID   int `fake:"{number:0,2147483647}"` // max int32
-	OrderIndex   int `fake:"{number:0,2147483647}"` // max int32
+	PanelOrderID int64 `fake:"{number:1,1462491394}"`
+	QuestionID   int   `fake:"{number:1,3117100}"`
+	OrderIndex   int   `fake:"{number:0,1000}"`
 }
 
 type PanelOrderItems []PanelOrderItem


### PR DESCRIPTION
- add DataItem interface
- add DataItems type
- add processBatch function to handle multiple data types
- add switch statement to handle multiple data types in bulkInserter






<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `DataItem` インターフェースと `DataItems` 型を追加し、複数のデータ型を処理するためのロジックをリファクタリングしました。
- New Feature: `processBatch` 関数を追加し、バッチ処理の効率性を向上させました。
- Refactor: `bulkInserter` にスイッチ文を追加し、複数のデータ型を処理できるようにしました。
- Refactor: `PanelOrderItems` 型を `DataItems` 型に置き換え、エラーチャネルを追加しました。
- New Feature: `PanelOrderItem` 構造体に新たなフィールドを追加し、`BulkInsert` メソッドを導入しました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->