### PR TITLE
fix: add AllowNativePasswords to DBConfig

### DIFF
--- a/database_test.go
+++ b/database_test.go
@@ -140,12 +140,12 @@ func TestGetEnvAsBool(t *testing.T) {
 		want  bool
 	}{
 		{
-			name:  "Successful Get Env Bool by Default",
+			name:  "Get Env Bool with false by Default",
 			setup: func() {},
 			want:  false,
 		},
 		{
-			name: "Successful Get Env Bool by Env",
+			name: "Get Env Bool with true in lowercase",
 			setup: func() {
 				// set env
 				t.Setenv("TEST_BOOL", "true")
@@ -153,7 +153,7 @@ func TestGetEnvAsBool(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Get Env Bool with different casing",
+			name: "Get Env Bool with true in Titlecase",
 			setup: func() {
 				// set env
 				t.Setenv("TEST_BOOL", "True")
@@ -161,7 +161,7 @@ func TestGetEnvAsBool(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Get Env Bool with different casing",
+			name: "Get Env Bool with true in Uppercase",
 			setup: func() {
 				// set env
 				t.Setenv("TEST_BOOL", "TRUE")
@@ -169,7 +169,7 @@ func TestGetEnvAsBool(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Get Env Bool with different casing",
+			name: "Get Env Bool with false as 0",
 			setup: func() {
 				// set env
 				t.Setenv("TEST_BOOL", "0")
@@ -177,7 +177,7 @@ func TestGetEnvAsBool(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "Get Env Bool with different casing",
+			name: "Get Env Bool with true as 1",
 			setup: func() {
 				// set env
 				t.Setenv("TEST_BOOL", "1")

--- a/database_test.go
+++ b/database_test.go
@@ -132,3 +132,35 @@ func TestGetEnvAddr(t *testing.T) {
 		})
 	}
 }
+
+func TestGetEnvAsBool(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func()
+		want  bool
+	}{
+		{
+			name:  "Successful Get Env Bool by Default",
+			setup: func() {},
+			want:  false,
+		},
+		{
+			name: "Successful Get Env Bool by Env",
+			setup: func() {
+				// set env
+				t.Setenv("TEST_BOOL", "true")
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			got := getEnvAsBool("TEST_BOOL", false)
+			if got != tt.want {
+				t.Errorf("getEnvAsBool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/database_test.go
+++ b/database_test.go
@@ -152,6 +152,38 @@ func TestGetEnvAsBool(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "Get Env Bool with different casing",
+			setup: func() {
+				// set env
+				t.Setenv("TEST_BOOL", "True")
+			},
+			want: true,
+		},
+		{
+			name: "Get Env Bool with different casing",
+			setup: func() {
+				// set env
+				t.Setenv("TEST_BOOL", "TRUE")
+			},
+			want: true,
+		},
+		{
+			name: "Get Env Bool with different casing",
+			setup: func() {
+				// set env
+				t.Setenv("TEST_BOOL", "0")
+			},
+			want: false,
+		},
+		{
+			name: "Get Env Bool with different casing",
+			setup: func() {
+				// set env
+				t.Setenv("TEST_BOOL", "1")
+			},
+			want: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: `DBConfig`構造体と`mysql.Config`に`AllowNativePasswords`フィールドが追加され、MySQLデータベースへの接続時にネイティブパスワードを許可するかどうかを制御できるようになりました。
- Test: 環境変数からブール値を取得するための新しいヘルパー関数`getEnvAsBool`とそのテストケースが追加されました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->